### PR TITLE
Update index.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,7 @@ module.exports = function i18n(customConf) {
       .pipe(debug({ title: '[I18N translating ' + lang + '] ' }))
       .pipe(replace(conf.regDelimeter, function (match, target) {
         // no need to translate, just trim the delimeters
-        if (lang === conf.sourceLang) return target;
+        //if (lang === conf.sourceLang) return target;
         
         var translation = locales[lang][target];
         return typeIs.undefined(translation) ?


### PR DESCRIPTION
对于sourceLang 直接跳过处理不建议这样做或增加配置来开关这个选项，
比如对于大段文字翻译我有可能会定义一个短字符做key来替换，默认语言下也同样有这种应用场景，这种情况下直接返回target就会有问题